### PR TITLE
Resolves #4. 

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -182,7 +182,7 @@ class SlugBehavior extends Behavior
             throw new InvalidArgumentException('The `slug` key is required by the `slugged` finder.');
         }
 
-        return $query->where([$this->config('field') => $options['slug']]);
+        return $query->where([$this->_table->alias() . '.' . $this->config('field') => $options['slug']]);
     }
 
     /**

--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -182,7 +182,7 @@ class SlugBehavior extends Behavior
             throw new InvalidArgumentException('The `slug` key is required by the `slugged` finder.');
         }
 
-        return $query->where([$this->_table->alias() . '.' . $this->config('field') => $options['slug']]);
+        return $query->where([$this->_table->aliasField($this->config('field')) => $options['slug']]);
     }
 
     /**

--- a/tests/Fixture/ArticlesTagsFixture.php
+++ b/tests/Fixture/ArticlesTagsFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @category UseMuffin-Slug
+ * @package ArticlesTagsFixture.php
+ *
+ * @author David Yell <neon1024@gmail.com>
+ * @when 15/07/15
+ *
+ */
+
+namespace Muffin\Slug\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class ArticlesTagsFixture extends TestFixture
+{
+    public $table = 'slug_articles_tags';
+
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'article_id' => ['type' => 'integer'],
+        'slug_tag_id' => ['type' => 'integer']
+    ];
+
+    public $records = [
+        ['article_id' => 1, 'slug_tag_id' => 1],
+        ['article_id' => 1, 'slug_tag_id' => 2],
+        ['article_id' => 2, 'slug_tag_id' => 2],
+    ];
+}

--- a/tests/Fixture/ArticlesTagsFixture.php
+++ b/tests/Fixture/ArticlesTagsFixture.php
@@ -1,14 +1,5 @@
 <?php
 
-/**
- * @category UseMuffin-Slug
- * @package ArticlesTagsFixture.php
- *
- * @author David Yell <neon1024@gmail.com>
- * @when 15/07/15
- *
- */
-
 namespace Muffin\Slug\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -204,7 +204,7 @@ class SlugBehaviorTest extends TestCase
     {
         $result = $this->Tags->find('slugged')->first();
     }
-    
+
     public function testContainSluggedTables()
     {
         TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -12,6 +12,7 @@ class SlugBehaviorTest extends TestCase
     public $fixtures = [
         'plugin.Muffin/Slug.Tags',
         'plugin.Muffin/Slug.Articles',
+        'plugin.Muffin/Slug.ArticlesTags'
     ];
 
     public function setUp()
@@ -202,5 +203,24 @@ class SlugBehaviorTest extends TestCase
     public function testFinderException()
     {
         $result = $this->Tags->find('slugged')->first();
+    }
+    
+    public function testContainSluggedTables()
+    {
+        TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);
+
+        $this->Tags->belongsToMany('Muffin/Slug.Articles', [
+            'joinTable' => 'slug_articles_tags',
+            'through' => TableRegistry::get('Muffin/Slug.ArticlesTags', ['table' => 'slug_articles_tags'])
+        ]);
+
+        $result = $this->Tags->find('slugged', ['slug' => 'color'])
+            ->contain(['Articles'])
+            ->first()
+            ->toArray();
+
+        $this->assertArrayHasKey('articles', $result);
+        $this->assertEquals(1, $result['id']);
+        $this->assertCount(1, $result['articles']);
     }
 }


### PR DESCRIPTION
Add the table class alias to the field to prevent ambiguous field when containing tables which also have a slug field.