### PR TITLE
Replace single and double quotes with empty string.

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -51,6 +51,8 @@ class SlugBehavior extends Behavior
             '?' => 'question',
             '+' => 'and',
             '&' => 'and',
+            '"' => '',
+            "'" => ''
         ],
         'maxLength' => null,
         'slugger' => 'Muffin\Slug\Slugger\CakeSlugger',

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -122,6 +122,10 @@ class SlugBehaviorTest extends TestCase
         $result = $this->Behavior->slug('foo/bar', '_');
         $expected = 'foo_bar';
         $this->assertEquals($expected, $result);
+
+        $result = $this->Behavior->slug('admad\'s "double quote "');
+        $expected = 'admads-double-quote';
+        $this->assertEquals($expected, $result);
     }
 
     public function testBeforeSaveMultiField()


### PR DESCRIPTION
For string `admad's` generally the preferred slug is `admads` instead of `admad-s`.