### PR TITLE
Allow skipping optional empty fields.

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -197,7 +197,11 @@ class SlugBehavior extends Behavior
             if (!isset($entity->{$field}) && !$entity->isNew()) {
                 return;
             }
-            $parts[] = $entity->{$field};
+
+            $value = $entity->{$field};
+            if (!empty($value) || is_numeric($value)) {
+                $parts[] = $value;
+            }
         }
 
         $slug = $this->slug($entity, implode($config['separator'], $parts), $config['separator']);

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -167,6 +167,24 @@ class SlugBehaviorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testBeforeSaveMultiWithOptionalField()
+    {
+        $Articles = TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);
+        $Articles->addBehavior('Muffin/Slug.Slug', [
+            'displayField' => ['title', 'sub_title'],
+            'implementedEvents' => [
+                'Model.beforeSave' => 'beforeSave',
+            ]
+        ]);
+
+        $data = ['title' => 'foo', 'sub_title' => ''];
+        $article = $Articles->newEntity($data);
+
+        $result = $Articles->save($article)->slug;
+        $expected = 'foo';
+        $this->assertEquals($expected, $result);
+    }
+
     public function testCustomSlugField()
     {
         $Articles = TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);


### PR DESCRIPTION
Without this patch you would end up with slug like "foo-" instead of "foo"