### PR TITLE
Allow generating slug using associated entity field.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
         "source": "https://github.com/usemuffin/slug"
     },
     "require": {
-        "cakephp/orm": "3.*"
+        "cakephp/orm": "~3.1"
     },
     "require-dev": {
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "~3.1",
         "phpunit/phpunit": "4.1.*",
         "cocur/slugify": "^1.2"
     },

--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -7,6 +7,7 @@ use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Muffin\Slug\SluggerInterface;
@@ -168,8 +169,10 @@ class SlugBehavior extends Behavior
     public function buildValidator(Event $event, Validator $validator, $name)
     {
         foreach ((array)$this->config('displayField') as $field) {
-            $validator->requirePresence($field, 'create')
-                ->notEmpty($field);
+            if (strpos($field, '.') === false) {
+                $validator->requirePresence($field, 'create')
+                    ->notEmpty($field);
+            }
         }
     }
 
@@ -198,11 +201,12 @@ class SlugBehavior extends Behavior
         $fields = (array)$config['displayField'];
         $parts = [];
         foreach ($fields as $field) {
-            if (!isset($entity->{$field}) && !$entity->isNew()) {
+            $value = Hash::get($entity, $field);
+
+            if ($value === null && !$entity->isNew()) {
                 return;
             }
 
-            $value = $entity->{$field};
             if (!empty($value) || is_numeric($value)) {
                 $parts[] = $value;
             }

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -14,6 +14,7 @@ class ArticlesFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
+        'author_id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'null' => false],
         'sub_title' => ['type' => 'string', 'null' => false],
         'slug' => ['type' => 'string', 'null' => false],
@@ -28,9 +29,9 @@ class ArticlesFixture extends TestFixture
      * @var array
      */
     public $records = [
-        ['title' => 'First Article', 'sub_title' => 'subtitle 1', 'slug' => 'first-title'],
-        ['title' => 'Second Article', 'sub_title' => 'subtitle 2', 'slug' => 'second-title'],
-        ['title' => 'Third Article', 'sub_title' => 'subtitle 3', 'slug' => 'third-title'],
+        ['author_id' => 1, 'title' => 'First Article', 'sub_title' => 'subtitle 1', 'slug' => 'first-title'],
+        ['author_id' => 1, 'title' => 'Second Article', 'sub_title' => 'subtitle 2', 'slug' => 'second-title'],
+        ['author_id' => 1, 'title' => 'Third Article', 'sub_title' => 'subtitle 3', 'slug' => 'third-title'],
     ];
 
     public function init()

--- a/tests/Fixture/AuthorsFixture.php
+++ b/tests/Fixture/AuthorsFixture.php
@@ -1,0 +1,30 @@
+<?php
+namespace Muffin\Slug\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class AuthorsFixture extends TestFixture
+{
+    public $table = 'slug_authors';
+
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string', 'null' => false],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['name' => 'admad'],
+        ['name' => 'jadb'],
+    ];
+}

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -12,7 +12,8 @@ class SlugBehaviorTest extends TestCase
     public $fixtures = [
         'plugin.Muffin/Slug.Tags',
         'plugin.Muffin/Slug.Articles',
-        'plugin.Muffin/Slug.ArticlesTags'
+        'plugin.Muffin/Slug.ArticlesTags',
+        'plugin.Muffin/Slug.Authors'
     ];
 
     public function setUp()
@@ -189,6 +190,23 @@ class SlugBehaviorTest extends TestCase
 
         $result = $Articles->save($article)->slug;
         $expected = 'foo';
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testBeforeSaveSlugGenerationWithAssociatedTableField()
+    {
+        $Articles = TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);
+        $Authors = TableRegistry::get('Muffin/Slug.Authors', ['table' => 'slug_authors']);
+
+        $Articles->belongsTo('Authors', ['className' => 'Muffin/Slug.Authors']);
+        $Articles->addBehavior('Muffin/Slug.Slug', ['displayField' => ['author.name', 'title']]);
+
+        $data = ['title' => 'foo', 'sub_title' => 'unused'];
+        $article = $Articles->newEntity($data);
+        $article->author = $Authors->get(1);
+
+        $result = $Articles->save($article)->slug;
+        $expected = 'admad-foo';
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
Hash::get() doesn't support entities (ArrayAccess) in 3.0 so will have to bump core version.