### PR TITLE
Create slug for new records if slug field is dirty but empty.

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -185,9 +185,13 @@ class SlugBehavior extends Behavior
     {
         $config = $this->_config;
 
-        $return = $entity->dirty($config['field']) || (!$entity->isNew() && !$config['onUpdate']);
+        if (!$entity->isNew() && !$config['onUpdate']) {
+            return;
+        }
 
-        if ($return) {
+        if ($entity->dirty($config['field']) &&
+            (!$entity->isNew() || (!empty($entity->{$config['field']})))
+        ) {
             return;
         }
 

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -111,6 +111,13 @@ class SlugBehaviorTest extends TestCase
         $result = $this->Tags->save($tag)->slug;
         $expected = 'bar';
         $this->assertEquals($expected, $result);
+
+        $data = ['name' => 'baz', 'slug' => ''];
+        $tag = $this->Tags->newEntity($data);
+
+        $result = $this->Tags->save($tag)->slug;
+        $expected = 'baz';
+        $this->assertEquals($expected, $result);
     }
 
     public function testSlug()


### PR DESCRIPTION
This caters to use case where you want to allow user to enter custom
slug but if field is left empty slug should be auto generated.