### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ public function initialize(array $config)
 > configuration option.
 
 ### Searching
-If you want to find a record using it's slug, a custom finder is provided by the plugin.
+If you want to find a record using its slug, a custom finder is provided by the plugin.
 
 ```php
 // src/Controller/ExamplesController.php


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!