### PR TITLE
Optionals

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -212,6 +212,10 @@ class SlugBehavior extends Behavior
             }
         }
 
+        if (!count($parts)) {
+            return;
+        }
+
         $slug = $this->slug($entity, implode($config['separator'], $parts), $config['separator']);
         $entity->set($config['field'], $slug);
     }

--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -11,7 +11,6 @@ use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Muffin\Slug\SluggerInterface;
-use UnexpectedValueException;
 
 /**
  * Slug behavior.

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -121,6 +121,27 @@ class SlugBehaviorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * Make sure no slug is generated when `displayField` is empty.
+     */
+    public function testBeforeSaveEmptyField()
+    {
+        $this->Tags->removeBehavior('Slug');
+        $this->Tags->addBehavior('Muffin/Slug.Slug', [
+            'displayField' => 'namespace',
+            'implementedEvents' => [
+                'Model.beforeSave' => 'beforeSave'
+            ]
+        ]);
+
+        $data = ['name' => 'foo'];
+        $tag = $this->Tags->newEntity($data);
+
+        $result = $this->Tags->save($tag)->slug;
+        $expected = null;
+        $this->assertEquals($expected, $result);
+    }
+
     public function testSlug()
     {
         $result = $this->Behavior->slug('foo/bar');


### PR DESCRIPTION
This PR prevents slugs from being created when `displayField` is empty, refs https://github.com/UseMuffin/Slug/issues/23.

Using this in my Behavior to disable the built-in `requirePresence` validation rule:

```php
$this->addBehavior('Muffin/Slug.Slug', [
    'displayField' => 'username',
    'onUpdate' => true, // update slug when record is updated
    'implementedEvents' => [
        'Model.beforeSave' => 'beforeSave' // disable SlugBehavior built-in `requirePresence` validation rule
     ]
]);
```

**Comparing situations:**  

Without this PR slugs are being generated when `username` fields is empty (undesired result, the first three records in image below).

After merging this PR the `slug` fields stays null unless `username` field actually contains a value (desired result, last two records).

![slug-empty-field](https://cloud.githubusercontent.com/assets/230500/15447842/8fb70eb8-1f4f-11e6-9b2e-9ff7860788e1.png)