### PR TITLE
Truncate slug when source field is longer than configured maxLength;

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -8,6 +8,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
+use Cake\Utility\Text;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Muffin\Slug\SluggerInterface;
@@ -292,7 +293,7 @@ class SlugBehavior extends Behavior
 
         $i = 0;
         $suffix = '';
-        $length = $this->config('length');
+        $length = $this->config('maxLength');
 
         while ($this->_table->exists($conditions)) {
             $i++;
@@ -320,6 +321,14 @@ class SlugBehavior extends Behavior
         if (is_object($callable) && $callable instanceof SluggerInterface) {
             $callable = [$callable, 'slug'];
         }
-        return $callable(str_replace(array_keys($replacements), $replacements, $string), $separator);
+        $slug = $callable(str_replace(array_keys($replacements), $replacements, $string), $separator);
+        if (!empty($this->config('maxLength'))) {
+            $slug = Text::truncate(
+                $slug,
+                $this->config('maxLength'),
+                ['ellipsis' => '']
+            );
+        }
+        return $slug;
     }
 }

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -11,7 +11,7 @@ class TagsFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'namespace' => ['type' => 'string', 'length' => 255, 'null' => true],
         'slug' => ['type' => 'string', 'length' => 255],
-        'name' => ['type' => 'string', 'length' => 255],
+        'name' => ['type' => 'string', 'length' => 320],
         'counter' => ['type' => 'integer', 'unsigned' => true, 'default' => 0, 'null' => true],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -247,6 +247,49 @@ class SlugBehaviorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testMaxLength()
+    {
+        $this->Tags->removeBehavior('Slug');
+        $this->Tags->addBehavior('Muffin/Slug.Slug');
+
+        $data = ['name' => 'This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters.'];
+        $tag = $this->Tags->newEntity($data);
+
+        $result = $this->Tags->save($tag)->slug;
+        $expected = 'this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extr';
+        $this->assertEquals($expected, $result);
+
+        $data2 = ['name' => 'This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters.'];
+        $tag2 = $this->Tags->newEntity($data2);
+
+        $result2 = $this->Tags->save($tag2)->slug;
+        $expected2 = 'this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-ex-1';
+        $this->assertEquals($expected2, $result2);
+    }
+
+
+    public function testCustomMaxLength()
+    {
+        $this->Tags->removeBehavior('Slug');
+        $this->Tags->addBehavior('Muffin/Slug.Slug', [
+            'maxLength' => 10
+        ]);
+
+        $data = ['name' => 'This tag name is longer than the configured maxLength.'];
+        $tag = $this->Tags->newEntity($data);
+
+        $result = $this->Tags->save($tag)->slug;
+        $expected = 'this-tag-n';
+        $this->assertEquals($expected, $result);
+
+        $data2 = ['name' => 'This tag name is not the same, but should cause a duplicate slug.'];
+        $tag2 = $this->Tags->newEntity($data2);
+
+        $result2 = $this->Tags->save($tag2)->slug;
+        $expected2 = 'this-tag-1';
+        $this->assertEquals($expected2, $result2);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -259,12 +259,11 @@ class SlugBehaviorTest extends TestCase
         $expected = 'this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extr';
         $this->assertEquals($expected, $result);
 
-        $data2 = ['name' => 'This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters. This is an extremely long title of more than 255 characters.'];
-        $tag2 = $this->Tags->newEntity($data2);
+        $tag = $this->Tags->newEntity($data);
 
-        $result2 = $this->Tags->save($tag2)->slug;
-        $expected2 = 'this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-ex-1';
-        $this->assertEquals($expected2, $result2);
+        $result = $this->Tags->save($tag)->slug;
+        $expected = 'this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-extremely-long-title-of-more-than-255-characters-this-is-an-ex-1';
+        $this->assertEquals($expected, $result);
     }
 
 
@@ -282,12 +281,12 @@ class SlugBehaviorTest extends TestCase
         $expected = 'this-tag-n';
         $this->assertEquals($expected, $result);
 
-        $data2 = ['name' => 'This tag name is not the same, but should cause a duplicate slug.'];
-        $tag2 = $this->Tags->newEntity($data2);
+        $data = ['name' => 'This tag name is not the same, but should cause a duplicate slug.'];
+        $tag = $this->Tags->newEntity($data);
 
-        $result2 = $this->Tags->save($tag2)->slug;
-        $expected2 = 'this-tag-1';
-        $this->assertEquals($expected2, $result2);
+        $result = $this->Tags->save($tag)->slug;
+        $expected = 'this-tag-1';
+        $this->assertEquals($expected, $result);
     }
 
     /**


### PR DESCRIPTION
add tests for max length and custom max length;
refs https://github.com/UseMuffin/Slug/issues/21 ;