### PR TITLE
Fixing slug with associated models when calling slug()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "cakephp/cakephp": "^3.2.7",
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "<6.0",
         "cocur/slugify": "^1.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "cakephp/cakephp": "^3.2.7",
-        "phpunit/phpunit": "<6.0",
+        "phpunit/phpunit": "5.7.*",
         "cocur/slugify": "^1.2"
     },
     "autoload": {

--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -262,7 +262,7 @@ class SlugBehavior extends Behavior
                 if ($entity->errors($field)) {
                     throw new InvalidArgumentException();
                 }
-                $string[] = $entity->get($field);
+                $string[] = Hash::get($entity, $field);
             }
             $string = implode($separator, $string);
         }

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -266,7 +266,6 @@ class SlugBehaviorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-
     public function testCustomMaxLength()
     {
         $this->Tags->removeBehavior('Slug');

--- a/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SlugBehaviorTest.php
@@ -390,4 +390,22 @@ class SlugBehaviorTest extends TestCase
         $result = $this->Behavior->slug('FOO');
         $this->assertEquals('foo', $result);
     }
+
+    public function testMultipleDisplayFieldsForSlug()
+    {
+        $Articles = TableRegistry::get('Muffin/Slug.Articles', ['table' => 'slug_articles']);
+        TableRegistry::get('Muffin/Slug.Authors', ['table' => 'slug_authors']);
+
+        $Articles->belongsTo('Authors', ['className' => 'Muffin/Slug.Authors']);
+        $Articles->addBehavior('Muffin/Slug.Slug', ['displayField' => ['author.name', 'title']]);
+
+        $entity = $Articles->get(1, [
+            'contain' => [
+                'Authors'
+            ]
+        ]);
+
+        $slug = $Articles->slug($entity);
+        $this->assertEquals('admad-first-article', $slug);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ unset($findRoot);
 chdir($root);
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
+
     return;
 }
 


### PR DESCRIPTION
### Fixes

* Fixed multiple displays fields, there was an issue with associated data, when calling slug() alone
* Added a test for that
* Remove php 5.4 from travis because of a phpunit limitation
* Changed phpunit dependency to v5.7.*

### Remaining issues (Thanks phpunit):

* The god damn phpunit dependency causes still failing tests for 5.6 for whatever reason. I need this *now* and going to use my fork until this gets merged.
* There is a phpcs issue that is related to the fact the plugin follows the cake convention of using `_` for `$_defaultSettings`. 
