### PR TITLE
Exceptions if slug field not exists or its length is NULL

### DIFF
--- a/src/Model/Behavior/SlugBehavior.php
+++ b/src/Model/Behavior/SlugBehavior.php
@@ -12,6 +12,7 @@ use Cake\Utility\Text;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Muffin\Slug\SluggerInterface;
+use RuntimeException;
 
 /**
  * Slug behavior.
@@ -113,10 +114,30 @@ class SlugBehavior extends Behavior
             $this->setConfig('displayField', $this->_table->getDisplayField());
         }
 
+        $field = $this->getConfig('field');
+
+        if (!$this->getTable()->hasField($field)) {
+            throw new RuntimeException(sprintf(
+                'SlugBehavior: Table `%s` is missing field `%s`',
+                $this->getTable()->getTable(),
+                $field
+            ));
+        }
+
+        $fieldSchema = $this->_table->getSchema()->getColumn($field);
+
         if ($this->getConfig('maxLength') === null) {
+            if ($fieldSchema['length'] === null) {
+                throw new RuntimeException(sprintf(
+                    'SlugBehavior: The schema for field `%s.%s` has no length defined',
+                    $this->getTable()->getTable(),
+                    $field
+                ));
+            }
+
             $this->setConfig(
                 'maxLength',
-                $this->_table->getSchema()->getColumn($this->getConfig('field'))['length']
+                $fieldSchema['length']
             );
         }
 

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -16,8 +16,8 @@ class ArticlesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'author_id' => ['type' => 'integer'],
         'title' => ['type' => 'string', 'null' => false],
-        'sub_title' => ['type' => 'string', 'null' => false],
-        'slug' => ['type' => 'string', 'null' => false],
+        'sub_title' => ['type' => 'string', 'null' => false, 'length' => 255],
+        'slug' => ['type' => 'string', 'null' => false, 'length' => 255],
         'created' => ['type' => 'datetime', 'null' => true],
         'modified' => ['type' => 'datetime', 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]


### PR DESCRIPTION
The exception if the DB field is missing is mostly a "in your face" notice for the developer.

The slug field should always have a fixed length. If it doesn't there might be problems with different DB systems / configs using different default lengths.